### PR TITLE
Suggestion: Always use the latest ember-cli-windows available.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "chalk": "^1.0.0",
-    "ember-cli-windows": "^1.3.0",
+    "ember-cli-windows": "latest",
     "rsvp": "^3.0.17",
     "touch": "0.0.3"
   }


### PR DESCRIPTION
I would suggest ember-cli-windows-addon should always use the latest ember-cli-windows available because the two are tightly coupled anyway and the only thing it's doing is invoking the binary so it shouldn't have any negative side-effects - e.g. I can't think of the case where the two could become incompatible. Thanks for considering and publishing the new version.
